### PR TITLE
Refactor GitHub Actions to use Docker Hub for image management

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,11 +12,10 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    environment: dev
+    environment: DockerHub
     if: startsWith(github.ref, 'refs/tags/')  # Only run on tag pushes
     
     permissions:
-      id-token: write
       contents: read
     
     steps:
@@ -39,12 +38,11 @@ jobs:
       id: extract_tag
       run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
     
-    - name: Azure Login with OIDC
-      uses: Azure/login@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
       with:
-        client-id: ${{ secrets.AZURE_CLIENT_ID }}
-        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
@@ -56,27 +54,19 @@ jobs:
         dotnet restore
         dotnet build --configuration Release --no-restore
     
-    - name: Login to Azure Container Registry
-      run: |
-        az acr login --name ${{ secrets.AZURE_CONTAINER_REGISTRY_NAME }}
-    
     - name: Build and push Docker image
       run: |
-        # Get the ACR login server
-        ACR_LOGIN_SERVER=$(az acr show --name ${{ secrets.AZURE_CONTAINER_REGISTRY_NAME }} --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --query "loginServer" --output tsv)
-        
         # Build the Docker image with tag version
-        docker build -t $ACR_LOGIN_SERVER/${{ env.IMAGE_NAME }}:${{ steps.extract_tag.outputs.tag }} .
-        docker build -t $ACR_LOGIN_SERVER/${{ env.IMAGE_NAME }}:latest .
+        docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.extract_tag.outputs.tag }} .
+        docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest .
         
         # Push the Docker image
-        docker push $ACR_LOGIN_SERVER/${{ env.IMAGE_NAME }}:${{ steps.extract_tag.outputs.tag }}
-        docker push $ACR_LOGIN_SERVER/${{ env.IMAGE_NAME }}:latest
+        docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.extract_tag.outputs.tag }}
+        docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
     
     - name: Output deployment information
       run: |
-        ACR_LOGIN_SERVER=$(az acr show --name ${{ secrets.AZURE_CONTAINER_REGISTRY_NAME }} --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --query "loginServer" --output tsv)
-        echo "Container Registry: $ACR_LOGIN_SERVER"
-        echo "Tagged Image: $ACR_LOGIN_SERVER/${{ env.IMAGE_NAME }}:${{ steps.extract_tag.outputs.tag }}"
-        echo "Latest Image: $ACR_LOGIN_SERVER/${{ env.IMAGE_NAME }}:latest"
+        echo "Docker Hub Repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}"
+        echo "Tagged Image: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.extract_tag.outputs.tag }}"
+        echo "Latest Image: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest"
         echo "Git Tag: ${{ steps.extract_tag.outputs.tag }}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A .NET Worker Service application to control Fujitsu General air conditioner louver position via the FGLair API. The service runs continuously in the background, monitoring and adjusting the louver position at configurable intervals.
 
-## Architecture
+## Architecture 
 
 This is a .NET 9 Worker Service that:
 - Uses `BackgroundService` for continuous operation


### PR DESCRIPTION
Transition the CI/CD workflow from Azure Container Registry to Docker Hub for image login and push operations, enhancing deployment efficiency.