### PR TITLE
Enhance GitHub Actions workflow to support tag pushes and main branch…

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v*'  # Trigger on version tags like v1.0.0, v2.1.3, etc.
-    branches: [ main ]  # Ensure tags are on main branch
+    branches: [ main ]  # Also trigger on pushes to main branch
 
 env:
   IMAGE_NAME: summer-chill
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: docker-hub
 
-    if: startsWith(github.ref, 'refs/tags/')  # Only run on tag pushes
+    # Run on tag pushes OR on main branch pushes that have a tag pointing to the same commit
+    if: startsWith(github.ref, 'refs/tags/') || (github.ref == 'refs/heads/main')
     permissions:
       contents: read
     
@@ -27,17 +28,37 @@ jobs:
     
     - name: Verify tag is on main branch
       run: |
-        # Check if the tag points to a commit that exists on main branch
-        TAG_COMMIT=$(git rev-list -n 1 ${{ github.ref }})
-        if ! git merge-base --is-ancestor $TAG_COMMIT origin/main; then
-          echo "Error: Tag ${{ github.ref }} is not on the main branch"
-          exit 1
+        if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          # Check if the tag points to a commit that exists on main branch
+          TAG_COMMIT=$(git rev-list -n 1 ${{ github.ref }})
+          if ! git merge-base --is-ancestor $TAG_COMMIT origin/main; then
+            echo "Error: Tag ${{ github.ref }} is not on the main branch"
+            exit 1
+          fi
+          echo "Tag ${{ github.ref }} is on main branch ✓"
+        else
+          echo "Triggered by push to main branch ✓"
         fi
-        echo "Tag ${{ github.ref }} is on main branch ✓"
     
     - name: Extract tag name
       id: extract_tag
-      run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      run: |
+        if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          # Direct tag push
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "Using tag from ref: $TAG_NAME"
+        else
+          # Main branch push - find the most recent tag for this commit
+          TAG_NAME=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          if [ -z "$TAG_NAME" ]; then
+            echo "Error: No tag found for the current commit on main branch"
+            echo "Please ensure the commit has a version tag before merging to main"
+            exit 1
+          fi
+          echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
+          echo "Using tag from commit: $TAG_NAME"
+        fi
     
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -72,5 +93,5 @@ jobs:
         echo "Docker Hub Repository: ${{ env.DOCKER_REPOSITORY }}"
         echo "Tagged Image: ${{ env.DOCKER_REPOSITORY }}:${{ steps.extract_tag.outputs.tag }}"
         echo "Latest Image: ${{ env.DOCKER_REPOSITORY }}:latest"
-
         echo "Git Tag: ${{ steps.extract_tag.outputs.tag }}"
+        echo "Triggered by: ${{ github.ref }}"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/build-and-deploy.yml` to enhance flexibility in triggering builds and improve tag validation logic. The most significant changes include allowing builds on both tag pushes and main branch pushes, adding checks to ensure tags are valid and associated with the main branch, and refining the tag extraction process.

### Workflow Trigger Enhancements:
* Modified the `on.push.branches` configuration to trigger builds on pushes to the `main` branch in addition to version tag pushes.
* Updated the `if` condition in the workflow to allow builds on tag pushes or main branch pushes with a tag pointing to the same commit.

### Tag Validation and Extraction Improvements:
* Added logic to verify whether a tag is associated with the main branch when triggered by a tag push. For main branch pushes, added a check to ensure the commit has a valid version tag.
* Enhanced the tag extraction step to differentiate between direct tag pushes and main branch pushes, ensuring the correct tag is used or providing error feedback if no tag is found.

### Logging Updates:
* Improved logging to include the trigger source (`github.ref`) in build output for better traceability.… triggers with improved tag verification