### PR TITLE
Refactor Worker class to use configurable interval for louver cycling…

### DIFF
--- a/FGLairSettings.cs
+++ b/FGLairSettings.cs
@@ -34,4 +34,9 @@ public class FGLairSettings
     /// The DSN (Device Serial Number) of the air conditioner
     /// </summary>
     public string DeviceDsn { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Interval in minutes between louver position changes
+    /// </summary>
+    public int Interval { get; set; } = 20;
 }


### PR DESCRIPTION
This pull request introduces a configurable interval for cycling the louver positions in the `Worker` class, allowing the interval to be set via the application configuration instead of being hardcoded. Additionally, it updates the `FGLairSettings` class to include a new property for the interval.

### Configuration updates:

* [`Worker.cs`](diffhunk://#diff-52f4833a718563924af32af788ff38c936dde2d37bf263ffab0fde1e57624e23R9): Added `_intervalMinutes` field to store the interval value, which is read from the configuration (`FGLair:Interval`). Updated logging and periodic timer logic to use this configurable interval. [[1]](diffhunk://#diff-52f4833a718563924af32af788ff38c936dde2d37bf263ffab0fde1e57624e23R9) [[2]](diffhunk://#diff-52f4833a718563924af32af788ff38c936dde2d37bf263ffab0fde1e57624e23R23-R25) [[3]](diffhunk://#diff-52f4833a718563924af32af788ff38c936dde2d37bf263ffab0fde1e57624e23L32-R36) [[4]](diffhunk://#diff-52f4833a718563924af32af788ff38c936dde2d37bf263ffab0fde1e57624e23L101-R107)

### Settings updates:

* [`FGLairSettings.cs`](diffhunk://#diff-8bf16ba15c382f284ef55838a50532619a4a9700531b07cda6896363128fffdeR37-R41): Added a new property `Interval` to specify the interval in minutes between louver position changes, with a default value of 20.… and update logging messages accordingly